### PR TITLE
`feat` update auth endpoint

### DIFF
--- a/core/helper/jwt.go
+++ b/core/helper/jwt.go
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-func GenerateJWT(nip string, role int) (string, error) {
+func GenerateJWT(nip string, role string) (string, error) {
 	var (
 		cfg       = config.ProvideConfig()
 		exp       = cfg.GetInt("JWT_EXPIRE")

--- a/core/middleware/authentication.go
+++ b/core/middleware/authentication.go
@@ -8,7 +8,7 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 )
 
-func Authenticate(role int) func(*fiber.Ctx) error {
+func Authenticate(role string) func(*fiber.Ctx) error {
 	cfg := config.ProvideConfig()
 	jwtSecret := cfg.Get("JWT_SECRET")
 
@@ -20,9 +20,9 @@ func Authenticate(role int) func(*fiber.Ctx) error {
 
 		SuccessHandler: func(c *fiber.Ctx) error {
 			claims := c.Locals("user").(*jwt.Token).Claims.(jwt.MapClaims)
-			user := int(claims["role"].(float64))
+			user := claims["role"].(string)
 
-			if role == 0 || user == role || user == 1 {
+			if user == "Admin" || user == role || role == "Public" {
 				return c.Next()
 			} else {
 				panic(exception.ForbiddenError{

--- a/module/akun/akun/controller/akun_controller_impl.go
+++ b/module/akun/akun/controller/akun_controller_impl.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"github.com/fathoor/simkes-api/core/exception"
+	"github.com/fathoor/simkes-api/core/middleware"
 	web "github.com/fathoor/simkes-api/core/model"
 	"github.com/fathoor/simkes-api/module/akun/akun/model"
 	"github.com/fathoor/simkes-api/module/akun/akun/service"
@@ -13,7 +14,7 @@ type akunControllerImpl struct {
 }
 
 func (controller *akunControllerImpl) Route(app *fiber.App) {
-	akun := app.Group("/v1/akun")
+	akun := app.Group("/v1/akun", middleware.Authenticate("Admin"))
 
 	akun.Post("/", controller.Create)
 	akun.Get("/", controller.GetAll)
@@ -21,7 +22,7 @@ func (controller *akunControllerImpl) Route(app *fiber.App) {
 	akun.Put("/detail/:nip", controller.Update)
 	akun.Delete("/detail/:nip", controller.Delete)
 
-	pegawai := app.Group("/v1/akun/pegawai")
+	pegawai := app.Group("/v1/akun/pegawai", middleware.Authenticate("Public"))
 
 	pegawai.Get("/detail/:nip", controller.PegawaiGet)
 	pegawai.Put("/detail/:nip", controller.PegawaiUpdate)

--- a/module/akun/role/controller/role_controller_impl.go
+++ b/module/akun/role/controller/role_controller_impl.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"github.com/fathoor/simkes-api/core/exception"
+	"github.com/fathoor/simkes-api/core/middleware"
 	web "github.com/fathoor/simkes-api/core/model"
 	"github.com/fathoor/simkes-api/module/akun/role/model"
 	"github.com/fathoor/simkes-api/module/akun/role/service"
@@ -13,7 +14,7 @@ type roleControllerImpl struct {
 }
 
 func (controller *roleControllerImpl) Route(app *fiber.App) {
-	role := app.Group("/v1/akun/role")
+	role := app.Group("/v1/akun/role", middleware.Authenticate("Admin"))
 
 	role.Post("/", controller.Create)
 	role.Get("/", controller.GetAll)

--- a/module/auth/controller/auth_controller_impl.go
+++ b/module/auth/controller/auth_controller_impl.go
@@ -13,7 +13,7 @@ type authControllerImpl struct {
 }
 
 func (controller *authControllerImpl) Route(app *fiber.App) {
-	auth := app.Group("/api/v1/auth")
+	auth := app.Group("/v1/auth")
 
 	auth.Post("/", controller.Login)
 }
@@ -22,10 +22,13 @@ func (controller *authControllerImpl) Login(c *fiber.Ctx) error {
 	var request model.AuthRequest
 
 	parse := c.BodyParser(&request)
-	exception.PanicIfError(parse)
+	if parse != nil {
+		panic(exception.BadRequestError{
+			Message: "Invalid request body",
+		})
+	}
 
-	response, err := controller.AuthService.Login(&request)
-	exception.PanicIfError(err)
+	response, _ := controller.AuthService.Login(&request)
 
 	return c.Status(fiber.StatusOK).JSON(web.Response{
 		Code:   fiber.StatusOK,

--- a/module/auth/service/auth_service_impl.go
+++ b/module/auth/service/auth_service_impl.go
@@ -34,7 +34,7 @@ func (service *authServiceImpl) Login(request *model.AuthRequest) (model.AuthRes
 		})
 	}
 
-	token, err := helper.GenerateJWT(akun.NIP, akun.RoleID)
+	token, err := helper.GenerateJWT(akun.NIP, akun.RoleName)
 	exception.PanicIfError(err)
 
 	response := model.AuthResponse{
@@ -43,7 +43,7 @@ func (service *authServiceImpl) Login(request *model.AuthRequest) (model.AuthRes
 		Expired: time.Now().Add(time.Hour * 24).Format("2006-01-02 15:04:05"),
 	}
 
-	return response, err
+	return response, nil
 }
 
 func ProvideAuthService(repository *repository.AkunRepository) AuthService {

--- a/module/auth/test/auth_test.go
+++ b/module/auth/test/auth_test.go
@@ -37,7 +37,7 @@ func TestAuth_Login(t *testing.T) {
 		requestBody, err := json.Marshal(authRequest)
 		assert.Nil(t, err)
 
-		request := httptest.NewRequest(http.MethodPost, "/api/v1/auth", strings.NewReader(string(requestBody)))
+		request := httptest.NewRequest(http.MethodPost, "/v1/auth", strings.NewReader(string(requestBody)))
 		request.Header.Set("Content-Type", "application/json")
 
 		response, err := app.Test(request)
@@ -53,7 +53,7 @@ func TestAuth_Login(t *testing.T) {
 		requestBody, err := json.Marshal(authRequest)
 		assert.Nil(t, err)
 
-		request := httptest.NewRequest(http.MethodPost, "/api/v1/auth", strings.NewReader(string(requestBody)))
+		request := httptest.NewRequest(http.MethodPost, "/v1/auth", strings.NewReader(string(requestBody)))
 		request.Header.Set("Content-Type", "application/json")
 
 		response, err := app.Test(request)
@@ -69,7 +69,7 @@ func TestAuth_Login(t *testing.T) {
 		requestBody, err := json.Marshal(authRequest)
 		assert.Nil(t, err)
 
-		request := httptest.NewRequest(http.MethodPost, "/api/v1/auth", strings.NewReader(string(requestBody)))
+		request := httptest.NewRequest(http.MethodPost, "/v1/auth", strings.NewReader(string(requestBody)))
 		request.Header.Set("Content-Type", "application/json")
 
 		response, err := app.Test(request)
@@ -85,7 +85,7 @@ func TestAuth_Login(t *testing.T) {
 		requestBody, err := json.Marshal(authRequest)
 		assert.Nil(t, err)
 
-		request := httptest.NewRequest(http.MethodPost, "/api/v1/auth", strings.NewReader(string(requestBody)))
+		request := httptest.NewRequest(http.MethodPost, "/v1/auth", strings.NewReader(string(requestBody)))
 		request.Header.Set("Content-Type", "application/json")
 
 		response, err := app.Test(request)

--- a/module/file/controller/file_controller_impl.go
+++ b/module/file/controller/file_controller_impl.go
@@ -14,7 +14,7 @@ type fileControllerImpl struct {
 }
 
 func (controller *fileControllerImpl) Route(app *fiber.App) {
-	file := app.Group("/api/v1/file", middleware.Authenticate(0))
+	file := app.Group("/v1/file", middleware.Authenticate("Public"))
 
 	file.Post("/", controller.Upload)
 	file.Get("/:filetype/:filename/download", controller.Download)

--- a/module/file/test/file_test.go
+++ b/module/file/test/file_test.go
@@ -46,7 +46,7 @@ func TestFile_Upload(t *testing.T) {
 		err = writer.Close()
 		assert.Nil(t, err)
 
-		request := httptest.NewRequest(http.MethodPost, "/api/v1/file", body)
+		request := httptest.NewRequest(http.MethodPost, "/v1/file", body)
 		request.Header.Set("Content-Type", writer.FormDataContentType())
 
 		response, err := app.Test(request)
@@ -66,7 +66,7 @@ func TestFile_Upload(t *testing.T) {
 		err = writer.Close()
 		assert.Nil(t, err)
 
-		request := httptest.NewRequest(http.MethodPost, "/api/v1/file", body)
+		request := httptest.NewRequest(http.MethodPost, "/v1/file", body)
 		request.Header.Set("Content-Type", writer.FormDataContentType())
 
 		response, err := app.Test(request)
@@ -89,7 +89,7 @@ func TestFile_Upload(t *testing.T) {
 		err = writer.Close()
 		assert.Nil(t, err)
 
-		request := httptest.NewRequest(http.MethodPost, "/api/v1/file", body)
+		request := httptest.NewRequest(http.MethodPost, "/v1/file", body)
 		request.Header.Set("Content-Type", writer.FormDataContentType())
 
 		response, err := app.Test(request)
@@ -100,7 +100,7 @@ func TestFile_Upload(t *testing.T) {
 
 func TestFile_Download(t *testing.T) {
 	t.Run("When file exist", func(t *testing.T) {
-		request := httptest.NewRequest(http.MethodGet, "/api/v1/file/image/4d32b23d-0927-457d-ab12-25bd632224b1.png/download", nil)
+		request := httptest.NewRequest(http.MethodGet, "/v1/file/image/4d32b23d-0927-457d-ab12-25bd632224b1.png/download", nil)
 
 		response, err := app.Test(request)
 		assert.Nil(t, err)
@@ -108,7 +108,7 @@ func TestFile_Download(t *testing.T) {
 	})
 
 	t.Run("When file not exist", func(t *testing.T) {
-		request := httptest.NewRequest(http.MethodGet, "/api/v1/file/image/4d32b23d-0927-457d-ab12-25bd632224b1.bmp/download", nil)
+		request := httptest.NewRequest(http.MethodGet, "/v1/file/image/4d32b23d-0927-457d-ab12-25bd632224b1.bmp/download", nil)
 
 		response, err := app.Test(request)
 		assert.Nil(t, err)
@@ -118,7 +118,7 @@ func TestFile_Download(t *testing.T) {
 
 func TestFile_Get(t *testing.T) {
 	t.Run("When file exist", func(t *testing.T) {
-		request := httptest.NewRequest(http.MethodGet, "/api/v1/file/image/4d32b23d-0927-457d-ab12-25bd632224b1.png", nil)
+		request := httptest.NewRequest(http.MethodGet, "/v1/file/image/4d32b23d-0927-457d-ab12-25bd632224b1.png", nil)
 
 		response, err := app.Test(request)
 		assert.Nil(t, err)
@@ -126,7 +126,7 @@ func TestFile_Get(t *testing.T) {
 	})
 
 	t.Run("When file not exist", func(t *testing.T) {
-		request := httptest.NewRequest(http.MethodGet, "/api/v1/file/image/4d32b23d-0927-457d-ab12-25bd632224b1.bmp", nil)
+		request := httptest.NewRequest(http.MethodGet, "/v1/file/image/4d32b23d-0927-457d-ab12-25bd632224b1.bmp", nil)
 
 		response, err := app.Test(request)
 		assert.Nil(t, err)
@@ -136,7 +136,7 @@ func TestFile_Get(t *testing.T) {
 
 func TestFile_Delete(t *testing.T) {
 	t.Run("When file exist", func(t *testing.T) {
-		request := httptest.NewRequest(http.MethodDelete, "/api/v1/file/image/4d32b23d-0927-457d-ab12-25bd632224b1.png", nil)
+		request := httptest.NewRequest(http.MethodDelete, "/v1/file/image/4d32b23d-0927-457d-ab12-25bd632224b1.png", nil)
 
 		response, err := app.Test(request)
 		assert.Nil(t, err)
@@ -144,7 +144,7 @@ func TestFile_Delete(t *testing.T) {
 	})
 
 	t.Run("When file not exist", func(t *testing.T) {
-		request := httptest.NewRequest(http.MethodDelete, "/api/v1/file/image/4d32b23d-0927-457d-ab12-25bd632224b1.bmp", nil)
+		request := httptest.NewRequest(http.MethodDelete, "/v1/file/image/4d32b23d-0927-457d-ab12-25bd632224b1.bmp", nil)
 
 		response, err := app.Test(request)
 		assert.Nil(t, err)


### PR DESCRIPTION
### Feature

- Auth endpoint now at `/v1/auth`
- Retrieved middleware back for #10 and #11
- Update auth middleware (JWT value)
```go
func GenerateJWT(nip string, role string) (string, error) {
    ...
}
```
- Update test cases

### Test

```bash
=== RUN   TestAuth_Login
=== RUN   TestAuth_Login/When_request_is_valid
=== RUN   TestAuth_Login/When_request_is_invalid
=== RUN   TestAuth_Login/When_NIP_is_invalid
=== RUN   TestAuth_Login/When_password_is_invalid

--- PASS: TestAuth_Login (0.16s)
    --- PASS: TestAuth_Login/When_request_is_valid (0.09s)
    --- PASS: TestAuth_Login/When_request_is_invalid (0.00s)
    --- PASS: TestAuth_Login/When_NIP_is_invalid (0.00s)
    --- PASS: TestAuth_Login/When_password_is_invalid (0.07s)
    
PASS
```