### PR TITLE
`feat` limit max upload size

### DIFF
--- a/module/file/test/file_test.go
+++ b/module/file/test/file_test.go
@@ -96,6 +96,29 @@ func TestFile_Upload(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Equal(t, fiber.StatusBadRequest, response.StatusCode)
 	})
+
+	t.Run("When file size exceeds limit", func(t *testing.T) {
+		body := new(bytes.Buffer)
+		writer := multipart.NewWriter(body)
+
+		file, err := writer.CreateFormFile("file", "default.png")
+		assert.Nil(t, err)
+		_, err = file.Write(fileTest)
+		assert.Nil(t, err)
+
+		err = writer.WriteField("type", "image")
+		assert.Nil(t, err)
+
+		err = writer.Close()
+		assert.Nil(t, err)
+
+		request := httptest.NewRequest(http.MethodPost, "/v1/file", body)
+		request.Header.Set("Content-Type", writer.FormDataContentType())
+
+		response, err := app.Test(request)
+		assert.Nil(t, err)
+		assert.Equal(t, fiber.StatusBadRequest, response.StatusCode)
+	})
 }
 
 func TestFile_Download(t *testing.T) {

--- a/module/file/validation/file_validation.go
+++ b/module/file/validation/file_validation.go
@@ -25,6 +25,12 @@ func ValidateFileRequest(request *model.FileRequest) (string, error) {
 				Message: fmt.Sprintf("Invalid file extension: %s is not supported", ext),
 			}
 		}
+
+		if request.File.Size > 2*1024*1024 {
+			return "", exception.BadRequestError{
+				Message: "File size exceeds limit",
+			}
+		}
 	default:
 		return "", exception.BadRequestError{
 			Message: fmt.Sprintf("Invalid file type: %s is not supported", request.Type),


### PR DESCRIPTION
### Feature

- New feature for #13 request
- File endpoint now at `/v1/file`
- Update test case for file upload size

### Test

```bash
=== RUN   TestFile_Upload
=== RUN   TestFile_Upload/When_file_and_type_is_valid
=== RUN   TestFile_Upload/When_file_is_invalid
=== RUN   TestFile_Upload/When_type_is_invalid
=== RUN   TestFile_Upload/When_file_size_exceeds_limit

--- PASS: TestFile_Upload (0.00s)
    --- PASS: TestFile_Upload/When_file_and_type_is_valid (0.00s)
    --- PASS: TestFile_Upload/When_file_is_invalid (0.00s)
    --- PASS: TestFile_Upload/When_type_is_invalid (0.00s)
    --- PASS: TestFile_Upload/When_file_size_exceeds_limit (0.00s)
    
=== RUN   TestFile_Download
=== RUN   TestFile_Download/When_file_exist
=== RUN   TestFile_Download/When_file_not_exist

--- PASS: TestFile_Download (0.00s)
    --- PASS: TestFile_Download/When_file_exist (0.00s)
    --- PASS: TestFile_Download/When_file_not_exist (0.00s)
    
=== RUN   TestFile_Get
=== RUN   TestFile_Get/When_file_exist
=== RUN   TestFile_Get/When_file_not_exist

--- PASS: TestFile_Get (0.00s)
    --- PASS: TestFile_Get/When_file_exist (0.00s)
    --- PASS: TestFile_Get/When_file_not_exist (0.00s)
    
=== RUN   TestFile_Delete
=== RUN   TestFile_Delete/When_file_exist
=== RUN   TestFile_Delete/When_file_not_exist

--- PASS: TestFile_Delete (0.00s)
    --- PASS: TestFile_Delete/When_file_exist (0.00s)
    --- PASS: TestFile_Delete/When_file_not_exist (0.00s)
    
PASS
```